### PR TITLE
eng(storybook):  Add Pan and Zoom to Device Preview ENG-13125

### DIFF
--- a/lib/src/editor/ui/editor.dart
+++ b/lib/src/editor/ui/editor.dart
@@ -61,17 +61,28 @@ class Editor extends StatelessWidget {
                     ),
                     Consumer<ZoomProvider>(
                       builder: (context, model, child) {
-                        return context.watch<DevicePreviewProvider>().show ? DevicePreview(
-                          builder: (context) {
-                            return Transform.scale(
-                              scale: model.zoom,
-                              child: component ?? const SizedBox.shrink(),
-                            );
-                          },
-                        ) : Transform.scale(
-                              scale: model.zoom,
-                              child: component ?? const SizedBox.shrink(),
-                            );
+                        TransformationController _transformation =
+                            TransformationController();
+                        _transformation.value = Matrix4.identity()
+                          ..scale(model.zoom);
+                        return context.watch<DevicePreviewProvider>().show
+                            ? DevicePreview(
+                                builder: (context) {
+                                  return InteractiveViewer(
+                                    panEnabled: true,
+                                    boundaryMargin:
+                                        EdgeInsets.all(double.infinity),
+                                    child: component ?? const SizedBox.shrink(),
+                                    transformationController: _transformation,
+                                  );
+                                },
+                              )
+                            : InteractiveViewer(
+                                panEnabled: true,
+                                boundaryMargin: EdgeInsets.all(double.infinity),
+                                transformationController: _transformation,
+                                child: component ?? const SizedBox.shrink(),
+                              );
                       },
                     ),
                   ],

--- a/lib/src/editor/ui/editor_tabs.dart
+++ b/lib/src/editor/ui/editor_tabs.dart
@@ -153,7 +153,6 @@ class _CoreContentTabsState extends State<CoreContentTabs> {
               },
             ),
           ),
-          const SizedBox(width: 8),
           TextButton(
             onPressed: context.read<DarkThemeProvider>().toggleDarkTheme,
             style: TextButton.styleFrom(
@@ -175,7 +174,7 @@ class _CoreContentTabsState extends State<CoreContentTabs> {
               },
             ),
           ),
-           const SizedBox(width: 8),
+          const SizedBox(width: 8),
           TextButton(
             onPressed: context.read<DevicePreviewProvider>().togglePreview,
             style: TextButton.styleFrom(
@@ -197,6 +196,7 @@ class _CoreContentTabsState extends State<CoreContentTabs> {
               },
             ),
           ),
+          const SizedBox(width: 8),
         ],
       ),
     );


### PR DESCRIPTION
By adding device preview, a lot of the default settings do not apply when the mode is enabled.

Therefore, I did two things:


- Add InteractiveViewer around the component state when device_preview is toggle to allow panning / zooming


https://user-images.githubusercontent.com/12024422/142059245-efdd321c-79a4-4d65-9734-60f819cf2188.mov





[ENG-13125](https://dutchie.atlassian.net/browse/ENG-13125)