### PR TITLE
eng(bugfix): Markdown throwing error when not passed

### DIFF
--- a/lib/src/editor/ui/doc_markdown.dart
+++ b/lib/src/editor/ui/doc_markdown.dart
@@ -9,7 +9,7 @@ class DocMarkDown extends StatelessWidget {
 
   const DocMarkDown({
     Key? key,
-    this.markdown = DEFAULT_MARKDOWN,
+    this.markdown,
   }) : super(key: key);
 
   @override
@@ -21,12 +21,11 @@ class DocMarkDown extends StatelessWidget {
       child: Markdown(
         styleSheet: MarkdownStyleSheet.fromTheme(Theme.of(context)),
         onTapText: () {
-          Clipboard.setData(new ClipboardData(text: markdown!));
-          Scaffold.of(context)
-              .showSnackBar(SnackBar(content: Text("Copy Code Snippet")));
+          Clipboard.setData(new ClipboardData(text: markdown ?? ''));
+          Scaffold.of(context).showSnackBar(SnackBar(content: Text("Copy Code Snippet")));
         },
         controller: controller,
-        data: markdown!,
+        data: markdown ?? DEFAULT_MARKDOWN,
         selectable: true,
         shrinkWrap: true,
       ),


### PR DESCRIPTION
Bugfix - Resolved issue with DEFAULT_MARKDOWN not getting used and generating an error on screen. 

Before:
![Screen Shot 2021-12-17 at 10 19 35 AM](https://user-images.githubusercontent.com/2012032/146578560-efe05ea2-911d-4b55-b85d-7568c2ffcd9c.png)

After:
![Screen Shot 2021-12-17 at 10 16 14 AM](https://user-images.githubusercontent.com/2012032/146578579-01196c80-1647-49c7-b846-5d97cd4c6843.png)

